### PR TITLE
Fixes for bugs and better QOL

### DIFF
--- a/scripts/salient_poses_menu.py
+++ b/scripts/salient_poses_menu.py
@@ -217,24 +217,18 @@ class SalientPosesDialog(MayaQWidgetDockableMixin, QtWidgets.QWidget):
  
     def set_start_frame_via_text(self):
         value = (self.start_edit.text())
-        self.start_slider.setValue(value)
-        MayaScene.set_animation_section(value, self.end_slider.value())
         self.n_keyframes_slider.setRange(*self.get_keyframe_range())
 
     def set_start_via_slider(self, value):
         self.start_edit.setText(str(value))
-        MayaScene.set_animation_section(value, self.end_slider.value())
         self.n_keyframes_slider.setRange(*self.get_keyframe_range())
 
     def set_end_frame_via_text(self):
         value = int(self.end_edit.text())
-        self.end_slider.setValue(value)
-        MayaScene.set_animation_section(self.start_slider.value(), value)
         self.n_keyframes_slider.setRange(*self.get_keyframe_range())
 
     def set_end_via_slider(self, value):
         self.end_edit.setText(str(value))
-        MayaScene.set_animation_section(self.start_slider.value(), value)
         self.n_keyframes_slider.setRange(*self.get_keyframe_range())
         
     def set_n_keyframes_via_text(self):

--- a/scripts/salient_poses_menu.py
+++ b/scripts/salient_poses_menu.py
@@ -143,6 +143,8 @@ class SalientPosesDialog(MayaQWidgetDockableMixin, QtWidgets.QWidget):
             self.animation_before_reduction[obj] = MayaScene.cache_animation_for_object(obj, int(self.start_edit.text()), int(self.end_edit.text()), ["tx", "ty", "tz", "rx", "ry", "rz"])
 
         selection = self.get_selection_of_n_keyframes(self.n_keyframes_slider.value())
+        # Turn off ghosting first!
+        mel.eval("unGhostAll")
         cmds.vuwReduceCommand(start=selection[0], finish=selection[-1], selection=selection)
 
     def undo_reduction(self):

--- a/scripts/salient_poses_menu.py
+++ b/scripts/salient_poses_menu.py
@@ -5,6 +5,8 @@ from shiboken2 import wrapInstance
 from maya.app.general.mayaMixin import MayaQWidgetBaseMixin, MayaQWidgetDockableMixin
 from maya import OpenMayaUI as omui 
 import maya.cmds as cmds
+import maya.mel as mel
+from shiboken2 import wrapInstance
 
 import salient_poses_utils as utils
 
@@ -18,13 +20,16 @@ DrawingBuilder = utils.DrawingBuilder
 MayaScene = utils.MayaScene
 
 
+def getMayaMainWindow():
+    mayaPtr = omui.MQtUtil.mainWindow()
+    return wrapInstance(long(mayaPtr), QtWidgets.QWidget)
+    
 _win = None
 def show():
     global _win
     if _win == None:
-        _win = SalientPosesDialog()
-    _win.show(dockable=False, floating=True)
-    # _win.show(dockable=True, area='right', floating=False)
+        _win = SalientPosesDialog(parent=getMayaMainWindow())
+    _win.show(dockable=True)
 
 class SalientPosesDialog(MayaQWidgetDockableMixin, QtWidgets.QWidget):
 

--- a/scripts/salient_poses_utils.py
+++ b/scripts/salient_poses_utils.py
@@ -533,17 +533,30 @@ class MayaScene:
         cmds.xform(object, worldSpace=True,  rotation=[x, y, z])
 
     @staticmethod
-    def cache_animation_for_object(obj, start_frame, end_frame, attributes):
+    def cache_animation_for_object(obj, start_frame, end_frame):
         animation = {}
-        for attr in attributes:
-            animation[attr] = [cmds.getAttr("%s.%s" % (obj, attr), time=i) for i in range(start_frame, end_frame + 1)]
+        curves = [x for x in cmds.listConnections(obj) if "animCurve" in cmds.nodeType(x)]
+        for curve in curves:
+            animation[curve] = [cmds.keyframe(curve, query=True, time=(i, i), eval=True)[0] for i in range(start_frame, end_frame + 1)]
         return animation
 
     @staticmethod
     def restore_animation_for_object(obj, animation, start_frame):
-        for attr in animation.keys():
-            for i, value in enumerate(animation[attr]):
-                cmds.setKeyframe(obj, value=value, attribute=attr, time=i+start_frame)
+        for curve in animation.keys():
+            for i, value in enumerate(animation[curve]):
+                cmds.setKeyframe(curve, value=value, time=i+start_frame)
+
+    @staticmethod
+    def set_all_keys_on_obj_between(obj, s, e):
+        for i in range(s, e + 1):
+            anim_curves = [x for x in cmds.listConnections(obj) if "animCurve" in cmds.nodeType(x)]
+            for anim_curve in anim_curves:
+                cmds.setKeyframe(anim_curve, t=(i,i))
+
+    @staticmethod
+    def set_all_keys_on_objs_between(objs, s, e):
+        for obj in objs:
+            MayaScene.set_all_keys_on_obj_between(obj, s, e)
 
 # 
 # --------------------------------------------------------------------------------------------------------------------#

--- a/scripts/salient_poses_utils.py
+++ b/scripts/salient_poses_utils.py
@@ -536,7 +536,7 @@ class MayaScene:
     def cache_animation_for_object(obj, start_frame, end_frame, attributes):
         animation = {}
         for attr in attributes:
-            animation[attr] = [cmds.getAttr("%s.%s" % (obj, attr), time=i) for i in range(start_frame, end_frame)]
+            animation[attr] = [cmds.getAttr("%s.%s" % (obj, attr), time=i) for i in range(start_frame, end_frame + 1)]
         return animation
 
     @staticmethod

--- a/src/MayaUtils.cpp
+++ b/src/MayaUtils.cpp
@@ -168,3 +168,14 @@ MTime::Unit MayaConfig::getCurrentFPS() {
         return MTime::kFilm;
     }
 }
+
+
+MAngle::Unit MayaConfig::getCurrentAngleUnit() {
+    MString angularUnit = MGlobal::optionVarStringValue(MString("workingUnitAngular"));
+    if (angularUnit == MString("deg")) {
+        return MAngle::kDegrees;
+    } else {
+        return MAngle::kRadians;
+    }
+}
+

--- a/src/MayaUtils.cpp
+++ b/src/MayaUtils.cpp
@@ -110,19 +110,19 @@ void MayaCheck::objectIsFloatArray(MObject obj) {
 
 MTime::Unit MayaConfig::getCurrentFPS() {
     MString ret = MGlobal::optionVarStringValue(MString("workingUnitTime"));
-         if (ret == MString("games"))     { return MTime::k15FPS; }
+         if (ret == MString("games"))     { return MTime::kGames; }
     else if (ret == MString("15fps"))     { return MTime::k15FPS; }
-    else if (ret == MString("film"))      { return MTime::k24FPS; }
+    else if (ret == MString("film"))      { return MTime::kFilm; }
     else if (ret == MString("24fps"))     { return MTime::k24FPS; }
-    else if (ret == MString("pal"))       { return MTime::k25FPS; }
+    else if (ret == MString("pal"))       { return MTime::kPALFrame; }
     else if (ret == MString("25fps"))     { return MTime::k25FPS; }
-    else if (ret == MString("ntsc"))      { return MTime::k30FPS; }
+    else if (ret == MString("ntsc"))      { return MTime::kNTSCFrame; }
     else if (ret == MString("30fps"))     { return MTime::k30FPS; }
-    // else if (ret == MString("ShowScan"))  { return MTime::k48FPS; }
+    else if (ret == MString("ShowScan"))  { return MTime::k48FPS; }
     else if (ret == MString("48fps"))     { return MTime::k48FPS; }
-    else if (ret == MString("palf"))      {  return MTime::k50FPS; }
+    else if (ret == MString("palf"))      {  return MTime::kPALField; }
     else if (ret == MString("50fps"))     { return MTime::k50FPS; }
-    else if (ret == MString("ntscf"))     { return MTime::k60FPS; }
+    else if (ret == MString("ntscf"))     { return MTime::kNTSCField; }
     else if (ret == MString("60fps"))     { return MTime::k60FPS; }
     else if (ret == MString("2fps")) { return MTime::k2FPS; }
     else if (ret == MString("3fps")) { return MTime::k3FPS; }

--- a/src/MayaUtils.hpp
+++ b/src/MayaUtils.hpp
@@ -12,6 +12,7 @@
 #include <maya/MObject.h>
 #include <maya/MStatus.h>
 #include <maya/MTime.h>
+#include <maya/MAngle.h>
 
 class Log {
 public:
@@ -56,6 +57,7 @@ public:
 class MayaConfig {
 public:
     static MTime::Unit getCurrentFPS();
+    static MAngle::Unit getCurrentAngleUnit();
 };
 
 

--- a/src/ReduceCommand.cpp
+++ b/src/ReduceCommand.cpp
@@ -29,6 +29,8 @@
 #include "MayaUtils.hpp"
 #include "ReduceCommand.hpp"
 
+#define RAD_TO_DEG 57.2958279088
+
 
 // Set name and flags
 const char* ReduceCommand::kName = "vuwReduceCommand";
@@ -85,6 +87,8 @@ MStatus ReduceCommand::doIt(const MArgList& args) {
     int nFrames = _finish - _start + 1;
     
     MTime::Unit timeUnit = MayaConfig::getCurrentFPS();
+    MAngle::Unit angleUnit = MayaConfig::getCurrentAngleUnit();
+    bool usingDegrees = angleUnit == MAngle::kDegrees;
     
     while (!iter.isDone()) {
         MObject mobj;
@@ -100,12 +104,20 @@ MStatus ReduceCommand::doIt(const MArgList& args) {
         for (int k = 0; k < plugs.length(); k++) {
             MFnAnimCurve curve(plugs[k]);
             
+            bool isAngluar = curve.animCurveType() == MFnAnimCurve::kAnimCurveTA;
+            
             // Cache the curve data
             std::vector<float> data;
             for (int i = _start; i < _finish + 1; i++) {
                 MTime time((double) (i), timeUnit);
                 float v = curve.evaluate(time);
-                data.push_back(v);
+                
+                if (isAngluar && usingDegrees) {
+                    data.push_back(v * RAD_TO_DEG);
+                } else {
+                    data.push_back(v);
+                }
+                
             }
             
             Interpolator interpolator = Interpolator::fromData(data, _selection, nFrames, _start);
@@ -133,7 +145,7 @@ MStatus ReduceCommand::doIt(const MArgList& args) {
                 curve.find(timeLeft, ixLeft);
                 curve.setWeightsLocked(ixLeft, false);
                 curve.setTangentsLocked(ixLeft, false);
-                curve.setAngle(ixLeft, MAngle(cubic.angleLeft()), false);
+                curve.setAngle(ixLeft, MAngle(cubic.angleLeft(), MAngle::kRadians), false);
                 curve.setWeight(ixLeft, cubic.weightLeft(), false);
                 
                 // Set incoming for right keyframe
@@ -142,7 +154,8 @@ MStatus ReduceCommand::doIt(const MArgList& args) {
                 curve.find(timeRight, ixRight);
                 curve.setWeightsLocked(ixRight, false);
                 curve.setTangentsLocked(ixRight, false);
-                curve.setAngle(ixRight, MAngle(cubic.angleRight()), true);
+                
+                curve.setAngle(ixRight, MAngle(cubic.angleRight(), MAngle::kRadians), true);
                 curve.setWeight(ixRight, cubic.weightRight(), true);
             }
         }

--- a/src/ReduceCommand.cpp
+++ b/src/ReduceCommand.cpp
@@ -112,10 +112,10 @@ MStatus ReduceCommand::doIt(const MArgList& args) {
             std::vector<Cubic> cubics = interpolator.getCubics();
             
             // Remove non-keyframes
-            for (int j = _start; j < _finish + 1; j++) {
+            for (int j = _start; j < _finish; j++) {
                 bool j_in_sel = std::find(_selection.begin(), _selection.end(), j) != _selection.end();
                 if (!j_in_sel) {
-                    MTime t((double) j, timeUnit);
+                    MTime t((double) j,timeUnit);
                     unsigned int ix = curve.findClosest(t);
                     curve.remove(ix);
                 }


### PR DESCRIPTION
Here I've made a number of relatively minor fixes to fix bugs and improve the quality. As a brief summary:

- the GUI is now a child of Maya, meaning that it floats correctly
- to address #8, all ghosts are removed before reduction
- the mapping from MString to Time::kUnit has been fixed (I hope)
- to address #12, Maya's angular working unit is now queried and used to amend data from the Maya's curve evaluation function (see #12  for more detail)
- as a temporary solution to #4, the tool bakes the animation curves before applying the reduction.

Finally, I've added a new pair of buttons that can be used to set, and later reset to, the original animation. 