### PR TITLE
New Interface Design and More Stability

### DIFF
--- a/maya/scripts/salient_poses_interface.py
+++ b/maya/scripts/salient_poses_interface.py
@@ -178,7 +178,9 @@ class SalientPosesGUI(altmaya.StandardMayaWindow):
             fixed_keyframes = sorted([float(v) for v in fixed_keyframes_raw])
         except ValueError:
             pass
-        self.extreme_selections = self.select("line", fixed_keyframes)
+        ret = self.select("line", fixed_keyframes)
+        if ret is None: return
+        self.extreme_selections = ret
         self.n_extreme_keyframes_slider.setMinimum(min(self.extreme_selections.keys()))
         self.n_extreme_keyframes_slider.setMaximum(max(self.extreme_selections.keys()))
         n = min(self.extreme_selections.keys())
@@ -191,7 +193,9 @@ class SalientPosesGUI(altmaya.StandardMayaWindow):
     def select_breakdowns(self):
         n = int(self.n_extreme_keyframes_slider.value())
         fixed_keyframes = sorted(self.extreme_selections[n]["selection"])
-        self.breakdown_selections = self.select("curve", fixed_keyframes)
+        ret = self.select("curve", fixed_keyframes)
+        if ret is None: return
+        self.breakdown_selections = ret
         self.n_breakdown_keyframes_slider.setMinimum(min(self.breakdown_selections.keys()))
         self.n_breakdown_keyframes_slider.setMaximum(max(self.breakdown_selections.keys()))
         n = min(self.breakdown_selections.keys())

--- a/maya/scripts/salient_poses_interface.py
+++ b/maya/scripts/salient_poses_interface.py
@@ -142,6 +142,17 @@ class SalientPosesGUI(altmaya.StandardMayaWindow):
 
         n_frames = end - start + 1
         max_keyframes = int(n_frames * 0.2) #int(self.max_keyframes_edit.text())
+
+        if len(fixed_keyframes) > 0:
+            max_k = max(fixed_keyframes)
+            min_k = min(fixed_keyframes)
+            if max_k > end:
+                altmaya.Report.error("a fixed keyframe greater than the last frame (fixed=%2.2f, last=%2.2f)" % (max_k, end))
+                return
+            elif min_k < start:
+                altmaya.Report.error("there is a fixed keyframe smaller than the first keyframe (fixed=%2.2f, first=%2.2f)" % (min_k, start))
+                return
+
         fixed_keyframes = [v - start for v in fixed_keyframes]
         result = maya.cmds.salientSelect(error_type, start, end, max_keyframes, fixed_keyframes, data)
         

--- a/maya/scripts/salient_poses_interface.py
+++ b/maya/scripts/salient_poses_interface.py
@@ -306,11 +306,17 @@ class SalientPosesGUI(altmaya.StandardMayaWindow):
         
     def reduce_using_extremes_only(self):
         n = int(self.n_extreme_keyframes_slider.value())
+        if n not in self.breakdown_selections.keys():
+            maya.Report.error("No extreme keyframes found for n=%d, did you run extreme selection?" % n)
+            return
         keyframes = self.extreme_selections[n]["selection"]
         self.reduce(keyframes)
         
     def reduce_using_breakdowns_as_well(self):
         n = int(self.n_breakdown_keyframes_slider.value())
+        if n not in self.breakdown_selections.keys():
+            maya.Report.error("No breakdown keyframes found for n=%d, did you run breakdown selection?" % n)
+            return
         keyframes = self.breakdown_selections[n]["selection"]
         self.reduce(keyframes)
         

--- a/maya/scripts/salient_poses_interface.py
+++ b/maya/scripts/salient_poses_interface.py
@@ -148,11 +148,6 @@ class SalientPosesGUI(altmaya.StandardMayaWindow):
         self.reduce_attr_gui.update_table()
         self.reduce_attr_gui.show()
         
-    def read_n_frames(self):
-        start = Timeline.get_start()
-        end = Timeline.get_end()
-        return end - start + 1
-         
     def select(self, error_type, fixed_keyframes):
         attr_indices = self.select_attr_gui.read_values_as_indices()
         if len(attr_indices) == 0:


### PR DESCRIPTION
I've spent some time upgrading the interface based on feedback. I think this new version brings together a bunch of small but important new features that will really artists use this tool with more ease. 

And, a big thanks to @davidkersey for their feedback which motivated these changes!

## Key Changes to Interface

Let me quickly go over these (basically summarizing f7ef625):

- The new layout of the tool is top-to-bottom linear. This means that, hopefully, artists roughly start with the buttons at the top and work their way down. Not sure it will be loved, but it's a least a step forward! The interface is divided into three core sections: (1) setup - basically just choosing fixed keyframes, (2) selection - choose attributes for selection and 

- There's a new table interface that collects information about "fixed keyframes". The artist should use this table to set up the range of animation to which the tool should select and apply keyframes. This table, as far as the algorithm is concerned, defines two things: (1) sets all fixed keyframes, and (2) indirectly defines the start/end frame for selection. For the artist, they can choose to set names and notes for their keyframes. 

- I've added locks to disable the keyframe sliders until the select buttons are pressed (these get locked again if the fixed keyframes change). Hopefully, this will help to reduce any confusion around accidentally using the slider before running the selection command.

- I've split up the attributes used for extremes and breakdowns. Keeping two channels separate adds a little bit more work for the artist, but will significantly reduce reentering values when an artist is exploring with the tool.

## Visualizing Keyframes

- I added a new button to "lock in" the extremes. This is cosmetic only but is helpful in that the artist can choose to duplicate an object at all extreme keyframes. This gives a visual point of difference when viewing potential keyframes.

- Extremes and breakdowns are entered correctly so that they appear visually different in the dope sheet and graph editor.

## Other Notes 

- I don't know if anyone will use the name and notes feature for fixed keyframes, but if they do I'll add a save/load feature.

- I'm open to reworking the interface design if it's not a good fit!

- There are no C++ changes here, just Python.

- (self-reminder) A bunch of the changes here rely on my [altmaya](https://github.com/richard-roberts/altmaya) project, which is still a work in progress. I'm not sure what the future of that project looks like, so if this version no longer works in the future that is likely why.